### PR TITLE
Rename apiGroup to kubedb.com

### DIFF
--- a/charts/capa-vpc-peering-operator/templates/cluster-role.yaml
+++ b/charts/capa-vpc-peering-operator/templates/cluster-role.yaml
@@ -11,12 +11,12 @@ rules:
   - awsmanagedcontrolplanes
   verbs: ["get", "list", "watch"]
 - apiGroups:
-  - ec2.aws.kubeform.com
+  - ec2.aws.kubedb.com
   resources:
   - vpcpeeringconnections
   verbs: ["get", "list", "watch"]
 - apiGroups:
-  - ec2.aws.kubeform.com
+  - ec2.aws.kubedb.com
   resources:
   - routes
   - securitygrouprules


### PR DESCRIPTION
Rename api group for vpcpeeringconnections, routes, securitygrouprules  to kubedb.com